### PR TITLE
Update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,15 @@
-lazy val catsEffectVersion    = "1.1.0"
-lazy val catsVersion          = "1.5.0"
-lazy val circeVersion         = "0.10.0"
-lazy val doobieVersion        = "0.6.0"
-lazy val fs2Version           = "1.0.2"
-lazy val kindProjectorVersion = "0.9.9"
-lazy val log4catsVersion      = "0.2.0"
-lazy val sangriaCirceVersion  = "1.2.1"
+lazy val catsEffectVersion    = "2.1.3"
+lazy val catsVersion          = "2.1.1"
+lazy val circeVersion         = "0.13.0"
+lazy val doobieVersion        = "0.9.0"
+lazy val fs2Version           = "2.3.0"
+lazy val kindProjectorVersion = "0.9.10"
+lazy val log4catsVersion      = "1.0.1"
+lazy val sangriaCirceVersion  = "1.3.0"
 lazy val sangriaVersion       = "1.4.2"
-lazy val scala12Version       = "2.12.8"
-lazy val http4sVersion        = "0.20.0-M4"
-lazy val slf4jVersion         = "1.7.25"
+lazy val scala12Version       = "2.12.11"
+lazy val http4sVersion        = "0.21.4"
+lazy val slf4jVersion         = "1.7.30"
 
 lazy val scalacSettings = Seq(
   scalacOptions ++=
@@ -18,7 +18,7 @@ lazy val scalacSettings = Seq(
       "-encoding", "utf-8",                // Specify character encoding used by source files.
       "-explaintypes",                     // Explain type errors in more detail.
       "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
-      "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
+      "-language:existentials",            // Existential types (besides wildcard types) can be written and inferreds
       "-language:higherKinds",             // Allow higher-kinded types
       "-language:implicitConversions",     // Allow definition of implicit functions called views
       "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ lazy val scalacSettings = Seq(
       "-encoding", "utf-8",                // Specify character encoding used by source files.
       "-explaintypes",                     // Explain type errors in more detail.
       "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
-      "-language:existentials",            // Existential types (besides wildcard types) can be written and inferreds
+      "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
       "-language:higherKinds",             // Allow higher-kinded types
       "-language:implicitConversions",     // Allow definition of implicit functions called views
       "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.

--- a/modules/core/src/main/scala/repo/CityRepo.scala
+++ b/modules/core/src/main/scala/repo/CityRepo.scala
@@ -4,7 +4,7 @@
 
 package demo.repo
 
-import cats._
+import cats.effect._
 import cats.implicits._
 import doobie._
 import doobie.implicits._
@@ -18,7 +18,7 @@ trait CityRepo[F[_]] {
 
 object CityRepo {
 
-  def fromTransactor[F[_]: Monad: Logger](xa: Transactor[F]): CityRepo[F] =
+  def fromTransactor[F[_]: Sync: Logger](xa: Transactor[F]): CityRepo[F] =
     new CityRepo[F] {
 
       val select: Fragment =

--- a/modules/core/src/main/scala/repo/CountryRepo.scala
+++ b/modules/core/src/main/scala/repo/CountryRepo.scala
@@ -4,8 +4,8 @@
 
 package demo.repo
 
-import cats._
 import cats.data._
+import cats.effect._
 import cats.implicits._
 import doobie._
 import doobie.implicits._
@@ -21,7 +21,7 @@ trait CountryRepo[F[_]] {
 
 object CountryRepo {
 
-  def fromTransactor[F[_]: Monad: Logger](xa: Transactor[F]): CountryRepo[F] =
+  def fromTransactor[F[_]: Sync: Logger](xa: Transactor[F]): CountryRepo[F] =
     new CountryRepo[F] {
 
       val select: Fragment =

--- a/modules/core/src/main/scala/repo/LanguageRepo.scala
+++ b/modules/core/src/main/scala/repo/LanguageRepo.scala
@@ -4,8 +4,8 @@
 
 package demo.repo
 
-import cats._
 import cats.data._
+import cats.effect.Sync
 import cats.implicits._
 import doobie._
 import doobie.implicits._
@@ -19,7 +19,7 @@ trait LanguageRepo[F[_]] {
 
 object LanguageRepo {
 
-  def fromTransactor[F[_]: Monad: Logger](xa: Transactor[F]): LanguageRepo[F] =
+  def fromTransactor[F[_]: Sync: Logger](xa: Transactor[F]): LanguageRepo[F] =
     new LanguageRepo[F] {
 
       val select: Fragment =

--- a/modules/core/src/main/scala/repo/MasterRepo.scala
+++ b/modules/core/src/main/scala/repo/MasterRepo.scala
@@ -4,7 +4,7 @@
 
 package demo.repo
 
-import cats._
+import cats.effect._
 import doobie._
 import io.chrisdavenport.log4cats.Logger
 
@@ -16,7 +16,7 @@ final case class MasterRepo[F[_]](
 
 object MasterRepo {
 
-  def fromTransactor[F[_]: Monad: Logger](xa: Transactor[F]): MasterRepo[F] =
+  def fromTransactor[F[_]: Sync: Logger](xa: Transactor[F]): MasterRepo[F] =
     MasterRepo(
       CityRepo.fromTransactor(xa),
       CountryRepo.fromTransactor(xa),

--- a/modules/core/src/main/scala/sangria/SangriaGraphQL.scala
+++ b/modules/core/src/main/scala/sangria/SangriaGraphQL.scala
@@ -71,7 +71,8 @@ object SangriaGraphQL {
       blockingExecutionContext: ExecutionContext
     )(
       implicit F: MonadError[F, Throwable],
-               L: LiftIO[F]
+               L: LiftIO[F],
+               C: ContextShift[IO]
     ): GraphQL[F] =
       new GraphQL[F] {
 

--- a/modules/core/src/main/scala/sangria/SangriaGraphQL.scala
+++ b/modules/core/src/main/scala/sangria/SangriaGraphQL.scala
@@ -13,7 +13,6 @@ import _root_.sangria.marshalling.circe._
 import _root_.sangria.parser.{ QueryParser, SyntaxError }
 import _root_.sangria.schema._
 import _root_.sangria.validation._
-import cats._
 import cats.effect._
 import cats.implicits._
 import io.circe.{ Json, JsonObject }
@@ -70,9 +69,7 @@ object SangriaGraphQL {
       userContext: F[A],
       blockingExecutionContext: ExecutionContext
     )(
-      implicit F: MonadError[F, Throwable],
-               L: LiftIO[F],
-               C: ContextShift[IO]
+      implicit F: Async[F],
     ): GraphQL[F] =
       new GraphQL[F] {
 
@@ -108,21 +105,22 @@ object SangriaGraphQL {
           variables:     JsonObject
         )(implicit ec: ExecutionContext): F[Either[Json, Json]] =
           userContext.flatMap { ctx =>
-            IO.fromFuture {
-              IO {
-                Executor.execute(
-                  schema           = schema,
-                  deferredResolver = deferredResolver,
-                  queryAst         = query,
-                  userContext      = ctx,
-                  variables        = Json.fromJsonObject(variables),
-                  operationName    = operationName,
-                  exceptionHandler = ExceptionHandler {
-                    case (_, e) ⇒ HandledException(e.getMessage)
-                  }
-                )
+            F.async { (cb: Either[Throwable, Json] => Unit) =>
+              Executor.execute(
+                schema           = schema,
+                deferredResolver = deferredResolver,
+                queryAst         = query,
+                userContext      = ctx,
+                variables        = Json.fromJsonObject(variables),
+                operationName    = operationName,
+                exceptionHandler = ExceptionHandler {
+                  case (_, e) ⇒ HandledException(e.getMessage)
+                }
+              ).onComplete {
+                case Success(value) => cb(Right(value))
+                case Failure(error) => cb(Left(error))
               }
-            } .to[F]
+            }
           } .attempt.flatMap {
             case Right(json)               => F.pure(json.asRight)
             case Left(err: WithViolations) => fail(formatWithViolations(err))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.3
+sbt.version=1.3.10

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
-addSbtPlugin("com.timushev.sbt"   % "sbt-updates"     % "0.3.4")
-addSbtPlugin("de.heikoseeberger"  % "sbt-header"      % "5.0.0")
+scalaVersion := "2.12.11"
+
+addSbtPlugin("com.timushev.sbt"   % "sbt-updates"     % "0.5.0")
+addSbtPlugin("de.heikoseeberger"  % "sbt-header"      % "5.6.0")
 addSbtPlugin("io.spray"           % "sbt-revolver"    % "0.9.1")
 


### PR DESCRIPTION
This PR would subsume https://github.com/tpolecat/doobie-http4s-sangria-grapgql-example/pull/3 and the work done by @Korbik

That change replaced `Monad` with `Sync`. It would also work to pass around an implicit `Bracket[F, Throwable]` if you want to avoid the power of `Sync`, although for what's going on `Sync` seems fine.

I'm not certain I've done the right thing with `SangriaGraphQL.scala` - the old IO code used `IO.fromFuture` but also wrapped the construction of the `Future` in an `IO`. It looks like `Async.async` should be safe on its own.