### PR TITLE
Update dependencies, including upgrade to Cats Effect 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ out/
 # Bloop/Metals
 .bloop
 .metals
+.bsp
+
+# VSCode
+.vscode

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,66 @@
+// mostly based on the config from Cats effect 3
+// https://raw.githubusercontent.com/typelevel/cats-effect/4711d7915544c177c4fb64c079a73461fe83f708/.scalafmt.conf
+version = 3.5.2
+maxColumn = 100
+align.preset = most
+align.multiline = false
+continuationIndent.defnSite = 2
+assumeStandardLibraryStripMargin = true
+docstrings.style = Asterisk
+docstrings.wrapMaxColumn = 80
+lineEndings = preserve
+includeCurlyBraceInSelectChains = false
+danglingParentheses.preset = true
+optIn.annotationNewlines = true
+newlines.alwaysBeforeMultilineDef = false
+runner.dialect = scala213
+rewrite.rules = [RedundantBraces]
+
+project.excludeFilters = [
+  "core/shared/src/main/scala/zio/Has.scala",
+  "core/shared/src/main/scala/zio/ZLayer.scala",
+  "core/shared/src/main/scala-2.x/zio/VersionSpecific.scala"
+]
+
+rewrite.redundantBraces.generalExpressions = false
+rewriteTokens = {
+  "⇒": "=>"
+  "→": "->"
+  "←": "<-"
+}
+
+# customisations below
+align.tokens = [
+    {
+      code = ":"
+      owners = [
+        { regex = "Term\\.Param", parents = [ "Ctor\\.Primary" ] },
+        { parents = [ "Defn\\." ]}
+      ]
+    },
+    {code = "{"},
+    {code = "->"},
+    {code = "<-"},
+    {code = "="},
+    {code = "%%"},
+    {code = "%"},
+    {code = ":="},
+    {code = "=>", owner = "Case"}
+]
+
+verticalMultiline.atDefnSite = true
+verticalMultiline.newlineAfterOpenParen = true
+verticalMultiline.arityThreshold = 3
+
+verticalAlignMultilineOperators = true
+newlines.forceBeforeMultilineAssign = def
+newlines.topLevelStatementBlankLines = [
+  { blanks = 1 }
+]
+newlines.beforeMultiline = fold
+newlines.beforeMultilineDef = fold
+
+align.closeParenSite = true
+align.openParenCallSite = true
+danglingParentheses.callSite = true
+danglingParentheses.defnSite = true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## doobie-http4s-sangria-grapgql-example
 
-Example app that uses doobie, http4s, and Sangria to serve GraphQL.
+Example app that uses doobie, http4s, Cats effect 3 and Sangria to serve GraphQL.
 
 This was bootstrapped from an [example](https://github.com/OlegIlyenko/sangria-http4s-graalvm-example) by @OlegIlyenko. Thanks!
 
@@ -19,6 +19,13 @@ or if you have bloop set up you can do
     bloop run core
 
 The go to http://localhost:8080 and play around.
+For example try this query, to see a list of cities starting with "Bei":
+
+    query {
+        cities(namePattern: "Bei%") {
+            name
+        }
+    }
 
 When you're done, ^C to kill the Scala server and
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,18 +1,16 @@
-lazy val catsEffectVersion    = "2.5.4"
-lazy val catsVersion          = "2.6.1"
+lazy val catsEffectVersion    = "3.3.11"
+lazy val catsVersion          = "2.7.0"
 lazy val circeVersion         = "0.14.1"
-lazy val doobieVersion        = "0.13.4"
-lazy val fs2Version           = "2.5.10"
+lazy val doobieVersion        = "1.0.0-RC2"
+lazy val fs2Version           = "3.2.5"
 lazy val kindProjectorVersion = "0.13.2"
-lazy val log4catsVersion      = "1.1.1"
-lazy val sangriaCirceVersion  = "1.3.0"
-lazy val sangriaVersion       = "2.1.6"
+lazy val log4catsVersion      = "2.2.0"
+lazy val sangriaCirceVersion  = "1.3.2"
+lazy val sangriaVersion       = "3.0.0"
 lazy val scala13Version       = "2.13.8"
-lazy val http4sVersion        = "0.21.33"
-lazy val slf4jVersion         = "1.7.30"
+lazy val http4sVersion        = "0.23.11"
 
 ThisBuild / scalaVersion := scala13Version
-//ThisBuild / scalacOptions += "-P:semanticdb:synthetics:on"
 
 lazy val scalacSettings = Seq(
   scalacOptions ++=
@@ -46,13 +44,11 @@ lazy val scalacSettings = Seq(
       "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
       "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
       "-Ywarn-unused:locals",              // Warn if a local definition is unused.
-//      "-Ywarn-unused:params",              // Warn if a value parameter is unused.
+      "-Ywarn-unused:params",              // Warn if a value parameter is unused.
       "-Ywarn-unused:privates",            // Warn if a private member is unused.
       "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
-//      "-Ywarn-macros:before", // via som
       "-Ymacro-annotations",
-      "-Yrangepos" // for longer squiggles
-//      "-Ypartial-unification"
+      "-Yrangepos"                         // for longer squiggles
     )
   ,
   (Compile / console / scalacOptions) --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports"),
@@ -98,7 +94,6 @@ lazy val core = project
       "org.http4s"           %% "http4s-blaze-server" % http4sVersion,
       "org.http4s"           %% "http4s-circe"        % http4sVersion,
       "io.circe"             %% "circe-optics"        % circeVersion,
-      "io.chrisdavenport"    %% "log4cats-slf4j"      % log4catsVersion,
-      "org.slf4j"            %  "slf4j-simple"        % slf4jVersion,
+      "org.typelevel"        %% "log4cats-slf4j"      % log4catsVersion
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,18 @@
-lazy val catsEffectVersion    = "2.1.3"
-lazy val catsVersion          = "2.1.1"
-lazy val circeVersion         = "0.13.0"
-lazy val doobieVersion        = "0.9.0"
-lazy val fs2Version           = "2.3.0"
-lazy val kindProjectorVersion = "0.9.10"
-lazy val log4catsVersion      = "1.0.1"
+lazy val catsEffectVersion    = "2.5.4"
+lazy val catsVersion          = "2.6.1"
+lazy val circeVersion         = "0.14.1"
+lazy val doobieVersion        = "0.13.4"
+lazy val fs2Version           = "2.5.10"
+lazy val kindProjectorVersion = "0.13.2"
+lazy val log4catsVersion      = "1.1.1"
 lazy val sangriaCirceVersion  = "1.3.0"
-lazy val sangriaVersion       = "1.4.2"
-lazy val scala12Version       = "2.12.11"
-lazy val http4sVersion        = "0.21.4"
+lazy val sangriaVersion       = "2.1.6"
+lazy val scala13Version       = "2.13.8"
+lazy val http4sVersion        = "0.21.33"
 lazy val slf4jVersion         = "1.7.30"
+
+ThisBuild / scalaVersion := scala13Version
+//ThisBuild / scalacOptions += "-P:semanticdb:synthetics:on"
 
 lazy val scalacSettings = Seq(
   scalacOptions ++=
@@ -18,22 +21,18 @@ lazy val scalacSettings = Seq(
       "-encoding", "utf-8",                // Specify character encoding used by source files.
       "-explaintypes",                     // Explain type errors in more detail.
       "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
+      "-language:postfixOps",
       "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
       "-language:higherKinds",             // Allow higher-kinded types
       "-language:implicitConversions",     // Allow definition of implicit functions called views
       "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
       "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
       "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
-      "-Xfuture",                          // Turn on future language features.
       "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-      "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
       "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
       "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
       "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
-      "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
-      "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
       "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
-      "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
       "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
       "-Xlint:option-implicit",            // Option.apply used implicit view.
       "-Xlint:package-object-classes",     // Class or object defined in package object.
@@ -41,35 +40,28 @@ lazy val scalacSettings = Seq(
       "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
       "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
       "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-      "-Xlint:unsound-match",              // Pattern match may not be typesafe.
-      "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
-      // "-Yno-imports",                      // No predef or default imports
-      "-Ypartial-unification",             // Enable partial unification in type constructor inference
       "-Ywarn-dead-code",                  // Warn when dead code is identified.
       "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-      "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
-      "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
-      "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
-      "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
       "-Ywarn-numeric-widen",              // Warn when numerics are widened.
       "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
       "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
       "-Ywarn-unused:locals",              // Warn if a local definition is unused.
-      "-Ywarn-unused:params",              // Warn if a value parameter is unused.
-      // "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+//      "-Ywarn-unused:params",              // Warn if a value parameter is unused.
       "-Ywarn-unused:privates",            // Warn if a private member is unused.
       "-Ywarn-value-discard",              // Warn when non-Unit expression results are unused.
-      "-Ywarn-macros:before", // via som
+//      "-Ywarn-macros:before", // via som
+      "-Ymacro-annotations",
       "-Yrangepos" // for longer squiggles
+//      "-Ypartial-unification"
     )
   ,
-  scalacOptions in (Compile, console) --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports"),
+  (Compile / console / scalacOptions) --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports"),
 )
 
 lazy val commonSettings = scalacSettings ++ Seq(
   organization := "org.tpolecat",
   licenses ++= Seq(("MIT", url("http://opensource.org/licenses/MIT"))),
-  scalaVersion := scala12Version,
+  scalaVersion := scala13Version,
   headerMappings := headerMappings.value + (HeaderFileType.scala -> HeaderCommentStyle.cppStyleLineComment),
   headerLicense  := Some(HeaderLicense.Custom(
     """|Copyright (c) 2018 by Rob Norris
@@ -77,7 +69,7 @@ lazy val commonSettings = scalacSettings ++ Seq(
        |For more information see LICENSE or https://opensource.org/licenses/MIT
        |""".stripMargin
   )),
-  addCompilerPlugin("org.spire-math" %% "kind-projector" % kindProjectorVersion),
+  addCompilerPlugin("org.typelevel" % "kind-projector" % "0.13.2" cross CrossVersion.full)
 )
 
 lazy val doobie_sangria = project.in(file("."))

--- a/modules/core/src/main/scala/GraphQL.scala
+++ b/modules/core/src/main/scala/GraphQL.scala
@@ -4,33 +4,41 @@
 
 package demo
 
-import io.circe.{ Json, JsonObject }
+import io.circe.Json
+import io.circe.JsonObject
 
-/** An algebra of operations in F that evaluate GraphQL requests. */
+/**
+ * An algebra of operations in F that evaluate GraphQL requests.
+ */
 trait GraphQL[F[_]] {
 
   /**
-   * Executes a JSON-encoded request in the standard POST encoding, described thus in the spec:
+   * Executes a JSON-encoded request in the standard POST encoding, described
+   * thus in the spec:
    *
-   * A standard GraphQL POST request should use the application/json content type, and include a
-   * JSON-encoded body of the following form:
+   * A standard GraphQL POST request should use the application/json content
+   * type, and include a JSON-encoded body of the following form:
    *
-   * {
-   *   "query": "...",
-   *   "operationName": "...",
-   *   "variables": { "myVariable": "someValue", ... }
-   * }
+   * { "query": "...", "operationName": "...", "variables": { "myVariable":
+   * "someValue", ... } }
    *
-   * `operationName` and `variables` are optional fields. `operationName` is only required if
-   * multiple operations are present in the query.
-   * @return either an error Json or result Json
+   * `operationName` and `variables` are optional fields. `operationName` is
+   * only required if multiple operations are present in the query.
+   * @return
+   *   either an error Json or result Json
    */
   def query(request: Json): F[Either[Json, Json]]
 
   /**
-   * Executes a request given a `query`, optional `operationName`, and `varianbles`.
-   * @return either an error Json or result Json
+   * Executes a request given a `query`, optional `operationName`, and
+   * `varianbles`.
+   * @return
+   *   either an error Json or result Json
    */
-  def query(query: String, operationName: Option[String], variables: JsonObject): F[Either[Json, Json]]
+  def query(
+    query: String,
+    operationName: Option[String],
+    variables: JsonObject
+  ): F[Either[Json, Json]]
 
 }

--- a/modules/core/src/main/scala/GraphQLRoutes.scala
+++ b/modules/core/src/main/scala/GraphQLRoutes.scala
@@ -14,12 +14,12 @@ import org.http4s.dsl._
 object GraphQLRoutes {
 
   /** An `HttpRoutes` that maps the standard `/graphql` path to a `GraphQL` instace. */
-  def apply[F[_]: Sync: ContextShift](
+  def apply[F[_]: Sync](
     graphQL:         GraphQL[F]
   ): HttpRoutes[F] = {
     object dsl extends Http4sDsl[F]; import dsl._
     HttpRoutes.of[F] {
-      case req @ POST -> Root / "graphql" ⇒
+      case req @ POST -> Root / "graphql" =>
         req.as[Json].flatMap(graphQL.query).flatMap {
           case Right(json) => Ok(json)
           case Left(json)  => BadRequest(json)

--- a/modules/core/src/main/scala/GraphQLRoutes.scala
+++ b/modules/core/src/main/scala/GraphQLRoutes.scala
@@ -13,17 +13,17 @@ import org.http4s.dsl._
 
 object GraphQLRoutes {
 
-  /** An `HttpRoutes` that maps the standard `/graphql` path to a `GraphQL` instace. */
-  def apply[F[_]: Sync](
-    graphQL:         GraphQL[F]
-  ): HttpRoutes[F] = {
+  /**
+   * An `HttpRoutes` that maps the standard `/graphql` path to a `GraphQL`
+   * instance.
+   */
+  def apply[F[_]: Async](graphQL: GraphQL[F]): HttpRoutes[F] = {
     object dsl extends Http4sDsl[F]; import dsl._
-    HttpRoutes.of[F] {
-      case req @ POST -> Root / "graphql" =>
-        req.as[Json].flatMap(graphQL.query).flatMap {
-          case Right(json) => Ok(json)
-          case Left(json)  => BadRequest(json)
-        }
+    HttpRoutes.of[F] { case req @ POST -> Root / "graphql" =>
+      req.as[Json].flatMap(graphQL.query).flatMap {
+        case Right(json) => Ok(json)
+        case Left(json)  => BadRequest(json)
+      }
     }
   }
 

--- a/modules/core/src/main/scala/Main.scala
+++ b/modules/core/src/main/scala/Main.scala
@@ -10,96 +10,84 @@ import demo.sangria.SangriaGraphQL
 import demo.schema._
 import doobie._
 import doobie.hikari._
-import doobie.util.ExecutionContexts
-import io.chrisdavenport.log4cats.Logger
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import repo._
 import _root_.sangria.schema._
+import cats.effect.std.Dispatcher
 import org.http4s._
+import org.http4s.blaze.server.BlazeServerBuilder
 import org.http4s.dsl._
 import org.http4s.headers.Location
-import org.http4s.implicits._
 import org.http4s.server.Server
-import org.http4s.server.blaze._
-import scala.concurrent.ExecutionContext
-import scala.concurrent.ExecutionContext.global
+import cats.effect.unsafe
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.http4s.implicits._
 
 object Main extends IOApp {
+  implicit val ioRuntime = unsafe.IORuntime
+  implicit val ec        = ioRuntime.global.compute
 
-  // Construct a transactor for connecting to the database.
-  def transactor[F[_]: Async: ContextShift](
-    blocker: Blocker
-  ): Resource[F, HikariTransactor[F]] =
-    ExecutionContexts.fixedThreadPool[F](10).flatMap { ce =>
-      HikariTransactor.newHikariTransactor(
-        "org.postgresql.Driver",
-        "jdbc:postgresql:world",
-        "user",
-        "password",
-        ce,
-        blocker
-      )
-    }
+  val hikariDataSourceConfig = {
+    val config = new HikariConfig()
+    config.setDriverClassName("org.postgresql.Driver")
+    config.setJdbcUrl("jdbc:postgresql:world")
+    config.setUsername("user")
+    config.setPassword("password")
+    config.setMaximumPoolSize(5)
+    config
+  }
+
+  def transactor[F[_]: Async]: IO[Transactor[F]] =
+    IO.pure(
+      HikariTransactor
+        .apply[F](new HikariDataSource(hikariDataSourceConfig), ioRuntime.global.compute)
+    )
 
   // Construct a GraphQL implementation based on our Sangria definitions.
-  def graphQL[F[_]: Effect: ContextShift: Logger](
-    transactor:      Transactor[F],
-    blockingContext: ExecutionContext
+  def graphQLServerFor[F[_]: Async](
+    dispatcher: Dispatcher[F],
+    transactor: Transactor[F]
   ): GraphQL[F] =
     SangriaGraphQL[F](
-      Schema(
-        query    = QueryType[F],
-        mutation = Some(MutationType[F])
-      ),
+      Schema(query = QueryType.apply[F](dispatcher), mutation = Some(MutationType[F](dispatcher))),
       WorldDeferredResolver[F],
       MasterRepo.fromTransactor(transactor).pure[F],
-      blockingContext
+      ec
     )
 
   // Playground or else redirect to playground
-  def playgroundOrElse[F[_]: Sync: ContextShift](
-    blocker: Blocker
-  ): HttpRoutes[F] = {
-    object dsl extends Http4sDsl[F]; import dsl._
+  def playgroundOrElse[F[_]: Async]: HttpRoutes[F] = {
+    object dsl extends Http4sDsl[F];
+    import dsl._
     HttpRoutes.of[F] {
 
       case GET -> Root / "playground.html" =>
-        StaticFile
-          .fromResource[F]("/assets/playground.html", blocker)
-          .getOrElseF(NotFound())
+        StaticFile.fromResource[F]("/assets/playground.html").getOrElseF(NotFound())
 
-      case _ =>
-        PermanentRedirect(Location(Uri.uri("/playground.html")))
+      case _ => PermanentRedirect(Location(uri"/playground.html"))
 
     }
   }
 
   // Resource that mounts the given `routes` and starts a server.
-  def server[F[_]: ConcurrentEffect: ContextShift: Timer](
-    routes: HttpRoutes[F]
-  ): Resource[F, Server[F]] =
-    BlazeServerBuilder[F](global)
-      .bindHttp(8080, "localhost")
+  def server[F[_]: Async](routes: HttpRoutes[F]): Resource[F, Server] =
+    BlazeServerBuilder[F]
+      .withExecutionContext(ioRuntime.global.compute)
+      .bindHttp(8080, "0.0.0.0")
       .withHttpApp(routes.orNotFound)
       .resource
 
-  // Resource that constructs our final server.
-  def resource[F[_]: ConcurrentEffect: ContextShift: Timer](
-    implicit L: Logger[F]
-  ): Resource[F, Server[F]] =
-    for {
-      b   <- Blocker[F]
-      xa  <- transactor[F](b)
-      gql  = graphQL[F](xa, b.blockingContext)
-      rts  = GraphQLRoutes[F](gql) <+> playgroundOrElse(b)
-      svr <- server[F](rts)
-    } yield svr
-
   // Our entry point starts the server and blocks forever.
   def run(args: List[String]): IO[ExitCode] = {
-    implicit val log = Slf4jLogger.getLogger[IO]
-    resource[IO].use(_ => IO.never.as(ExitCode.Success))
+    val resource = for {
+      xa           <- Resource.eval(transactor[IO])
+      dispatcher   <- Dispatcher[IO]
+      graphQlServer = graphQLServerFor[IO](dispatcher, xa)
+      routes        = GraphQLRoutes[IO](graphQlServer) <+> playgroundOrElse
+      server       <- server[IO](routes)
+    } yield server
+
+    resource.use(_ => IO.never.as(ExitCode.Success))
   }
 
 }
-

--- a/modules/core/src/main/scala/Main.scala
+++ b/modules/core/src/main/scala/Main.scala
@@ -14,7 +14,6 @@ import doobie.util.ExecutionContexts
 import io.chrisdavenport.log4cats.Logger
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import repo._
-import sangria._
 import _root_.sangria.schema._
 import org.http4s._
 import org.http4s.dsl._

--- a/modules/core/src/main/scala/model/City.scala
+++ b/modules/core/src/main/scala/model/City.scala
@@ -5,9 +5,8 @@
 package demo.model
 
 final case class City(
-  id:           Int,
-  name:         String,
-  countryCode:  String,
-  district:     String,
-  population:   Int,
-)
+  id:          Int,
+  name:        String,
+  countryCode: String,
+  district:    String,
+  population:  Int)

--- a/modules/core/src/main/scala/model/Country.scala
+++ b/modules/core/src/main/scala/model/Country.scala
@@ -5,19 +5,18 @@
 package demo.model
 
 final case class Country(
-  code:            String,
-  name:            String,
-  continent:       String,
-  region:          String,
-  surfacearea:     Float,
-  indepyear:       Option[Short],
-  population:      Int,
-  lifeexpectancy:  Option[Float],
-  gnp:             Option[BigDecimal],
-  gnpold:          Option[BigDecimal],
-  localname:       String,
-  governmentform:  String,
-  headofstate:     Option[String],
-  capitalId:       Option[Int],
-  code2:           String
-)
+  code:           String,
+  name:           String,
+  continent:      String,
+  region:         String,
+  surfacearea:    Float,
+  indepyear:      Option[Short],
+  population:     Int,
+  lifeexpectancy: Option[Float],
+  gnp:            Option[BigDecimal],
+  gnpold:         Option[BigDecimal],
+  localname:      String,
+  governmentform: String,
+  headofstate:    Option[String],
+  capitalId:      Option[Int],
+  code2:          String)

--- a/modules/core/src/main/scala/model/Language.scala
+++ b/modules/core/src/main/scala/model/Language.scala
@@ -5,8 +5,7 @@
 package demo.model
 
 final case class Language(
-  countryCode:  String,
-  language:     String,
-  isOfficial:   Boolean,
-  percentage:   Float
-)
+  countryCode: String,
+  language:    String,
+  isOfficial:  Boolean,
+  percentage:  Float)

--- a/modules/core/src/main/scala/repo/CountryRepo.scala
+++ b/modules/core/src/main/scala/repo/CountryRepo.scala
@@ -9,8 +9,10 @@ import cats.effect._
 import cats.implicits._
 import doobie._
 import doobie.implicits._
+//import doobie.syntax.all
 import demo.model._
 import io.chrisdavenport.log4cats.Logger
+import Fragments.in
 
 trait CountryRepo[F[_]] {
   def fetchByCode(code: String): F[Option[Country]]
@@ -41,7 +43,7 @@ object CountryRepo {
           case None      => List.empty[Country].pure[F]
           case Some(nel) =>
             Logger[F].info(s"CountryRepo.fetchByCodes(${codes.length} codes)") *>
-            (select ++ fr"where" ++ Fragments.in(fr"code", nel)).query[Country].to[List].transact(xa)
+            (select ++ fr"where" ++ in(fr"code", nel)).query[Country].to[List].transact(xa)
         }
 
       def fetchAll: F[List[Country]] =

--- a/modules/core/src/main/scala/repo/LanguageRepo.scala
+++ b/modules/core/src/main/scala/repo/LanguageRepo.scala
@@ -11,6 +11,7 @@ import doobie._
 import doobie.implicits._
 import demo.model._
 import io.chrisdavenport.log4cats.Logger
+import Fragments.in
 
 trait LanguageRepo[F[_]] {
   def fetchByCountryCode(code: String): F[List[Language]]
@@ -37,7 +38,7 @@ object LanguageRepo {
           case None      => Map.empty[String, List[Language]].pure[F]
           case Some(nel) =>
             Logger[F].info(s"LanguageRepo.fetchByCountryCodes(${codes.length} codes)") *>
-            (select ++ fr"where" ++ Fragments.in(fr"countrycode", nel))
+            (select ++ fr"where" ++ in(fr"countrycode", nel))
               .query[Language]
               .to[List]
               .map { ls =>

--- a/modules/core/src/main/scala/repo/LanguageRepo.scala
+++ b/modules/core/src/main/scala/repo/LanguageRepo.scala
@@ -10,8 +10,8 @@ import cats.implicits._
 import doobie._
 import doobie.implicits._
 import demo.model._
-import io.chrisdavenport.log4cats.Logger
 import Fragments.in
+import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 trait LanguageRepo[F[_]] {
   def fetchByCountryCode(code: String): F[List[Language]]
@@ -20,35 +20,40 @@ trait LanguageRepo[F[_]] {
 
 object LanguageRepo {
 
-  def fromTransactor[F[_]: Sync: Logger](xa: Transactor[F]): LanguageRepo[F] =
+  def fromTransactor[F[_]: Sync](xa: Transactor[F]): LanguageRepo[F] =
     new LanguageRepo[F] {
 
-      val select: Fragment =
-        fr"""
+      val select: Fragment = fr"""
           SELECT countrycode, language, isOfficial, percentage
           FROM   countrylanguage
         """
 
       def fetchByCountryCode(code: String): F[List[Language]] =
-        Logger[F].info(s"LanguageRepo.fetchByCountryCode($code)") *>
-        (select ++ sql"where countrycode = $code").query[Language].to[List].transact(xa)
+        for {
+          logger <- Slf4jLogger.create[F]
+          result <- logger.info(s"LanguageRepo.fetchByCountryCode($code)") *>
+                    (select ++ sql"where countrycode = $code").query[Language].to[List].transact(xa)
+        } yield result
 
       def fetchByCountryCodes(codes: List[String]): F[Map[String, List[Language]]] =
-        NonEmptyList.fromList(codes) match {
-          case None      => Map.empty[String, List[Language]].pure[F]
-          case Some(nel) =>
-            Logger[F].info(s"LanguageRepo.fetchByCountryCodes(${codes.length} codes)") *>
-            (select ++ fr"where" ++ in(fr"countrycode", nel))
-              .query[Language]
-              .to[List]
-              .map { ls =>
-                // Make sure we include empty lists for countries with no languages
-                codes.foldRight(ls.groupBy(_.countryCode)) { (c, m) =>
-                  Map(c -> List.empty[Language]) |+| m
-                }
-              }
-              .transact(xa)
-        }
+        for {
+          logger <- Slf4jLogger.create[F]
+          result <- NonEmptyList.fromList(codes) match {
+                      case None => Map.empty[String, List[Language]].pure[F]
+                      case Some(nel) => logger
+                          .info(s"LanguageRepo.fetchByCountryCodes(${codes.length} codes)") *>
+                        (select ++ fr"where" ++ in(fr"countrycode", nel))
+                          .query[Language]
+                          .to[List]
+                          .map { ls =>
+                            // Make sure we include empty lists for countries with no languages
+                            codes.foldRight(ls.groupBy(_.countryCode)) { (c, m) =>
+                              Map(c -> List.empty[Language]) |+| m
+                            }
+                          }
+                          .transact(xa)
+                    }
+        } yield result
 
     }
 

--- a/modules/core/src/main/scala/repo/MasterRepo.scala
+++ b/modules/core/src/main/scala/repo/MasterRepo.scala
@@ -6,21 +6,20 @@ package demo.repo
 
 import cats.effect._
 import doobie._
-import io.chrisdavenport.log4cats.Logger
 
 final case class MasterRepo[F[_]](
   city:     CityRepo[F],
   country:  CountryRepo[F],
-  language: LanguageRepo[F]
-)
+  language: LanguageRepo[F])
 
 object MasterRepo {
 
-  def fromTransactor[F[_]: Sync: Logger](xa: Transactor[F]): MasterRepo[F] =
-    MasterRepo(
-      CityRepo.fromTransactor(xa),
-      CountryRepo.fromTransactor(xa),
-      LanguageRepo.fromTransactor(xa)
-    )
+  def fromTransactor[F[_]: Sync](
+    xa: Transactor[F]
+  ): MasterRepo[F] =
+    MasterRepo(CityRepo.fromTransactor(xa),
+               CountryRepo.fromTransactor(xa),
+               LanguageRepo.fromTransactor(xa)
+              )
 
 }

--- a/modules/core/src/main/scala/sangria/SangriaGraphQL.scala
+++ b/modules/core/src/main/scala/sangria/SangriaGraphQL.scala
@@ -10,17 +10,23 @@ import _root_.sangria.execution._
 import _root_.sangria.execution.deferred._
 import _root_.sangria.execution.WithViolations
 import _root_.sangria.marshalling.circe._
-import _root_.sangria.parser.{ QueryParser, SyntaxError }
+import _root_.sangria.parser.QueryParser
+import _root_.sangria.parser.SyntaxError
 import _root_.sangria.schema._
 import _root_.sangria.validation._
 import cats.effect._
 import cats.implicits._
-import io.circe.{ Json, JsonObject }
+import io.circe.Json
+import io.circe.JsonObject
 import io.circe.optics.JsonPath.root
-import scala.concurrent.ExecutionContext
-import scala.util.{ Success, Failure }
 
-/** A GraphQL implementation based on Sangria. */
+import scala.util.Failure
+import scala.util.Success
+import scala.concurrent.ExecutionContext
+
+/**
+ * A GraphQL implementation based on Sangria.
+ */
 object SangriaGraphQL {
 
   // Some circe lenses
@@ -29,47 +35,68 @@ object SangriaGraphQL {
   private val variablesLens     = root.variables.obj
 
   // Format a SyntaxError as a GraphQL `errors`
-  private def formatSyntaxError(e: SyntaxError): Json = Json.obj(
-    "errors" -> Json.arr(Json.obj(
-      "message"   -> Json.fromString(e.getMessage),
-      "locations" -> Json.arr(Json.obj(
-        "line"   -> Json.fromInt(e.originalError.position.line),
-        "column" -> Json.fromInt(e.originalError.position.column))))))
+  private def formatSyntaxError(e: SyntaxError): Json =
+    Json.obj(
+      "errors" -> Json.arr(
+        Json.obj(
+          "message" -> Json
+            .fromString(e.getMessage),
+          "locations" -> Json
+            .arr(
+              Json.obj("line" -> Json
+                         .fromInt(e.originalError.position.line),
+                       "column" -> Json
+                         .fromInt(e.originalError.position.column)
+                      )
+            )
+        )
+      )
+    )
 
   // Format a WithViolations as a GraphQL `errors`
-  private def formatWithViolations(e: WithViolations): Json = Json.obj(
-    "errors" -> Json.fromValues(e.violations.map {
+  private def formatWithViolations(
+    e: WithViolations
+  ): Json =
+    Json.obj("errors" -> Json.fromValues(e.violations.map {
       case v: AstNodeViolation => Json.obj(
-        "message"   -> Json.fromString(v.errorMessage),
-        "locations" -> Json.fromValues(v.locations.map(loc => Json.obj(
-          "line"   -> Json.fromInt(loc.line),
-          "column" -> Json.fromInt(loc.column)))))
-      case v => Json.obj(
-        "message" -> Json.fromString(v.errorMessage))}))
+          "message" -> Json.fromString(v.errorMessage),
+          "locations" -> Json.fromValues(
+            v.locations
+              .map(loc =>
+                Json
+                  .obj("line" -> Json.fromInt(loc.line), "column" -> Json.fromInt(loc.column))
+              )
+          )
+        )
+      case v => Json.obj("message" -> Json.fromString(v.errorMessage))
+    }))
 
   // Format a String as a GraphQL `errors`
-  private def formatString(s: String): Json = Json.obj(
-    "errors" -> Json.arr(Json.obj(
-      "message" -> Json.fromString(s))))
+  private def formatString(s: String): Json =
+    Json.obj("errors" -> Json.arr(Json.obj("message" -> Json.fromString(s))))
 
   // Format a Throwable as a GraphQL `errors`
-  private def formatThrowable(e: Throwable): Json = Json.obj(
-    "errors" -> Json.arr(Json.obj(
-      "class"   -> Json.fromString(e.getClass.getName),
-      "message" -> Json.fromString(e.getMessage))))
+  private def formatThrowable(e: Throwable): Json =
+    Json.obj(
+      "errors" -> Json.arr(
+        Json.obj("class"   -> Json.fromString(e.getClass.getName),
+                 "message" -> Json.fromString(e.getMessage)
+                )
+      )
+    )
 
   // Partially-applied constructor
   def apply[F[_]] = new Partial[F]
+
   final class Partial[F[_]] {
 
     // The rest of the constructor
     def apply[A](
-      schema: Schema[A, Unit],
-      deferredResolver: DeferredResolver[A],
-      userContext: F[A],
+      schema:                   Schema[A, Unit],
+      deferredResolver:         DeferredResolver[A],
+      userContext:              F[A],
       blockingExecutionContext: ExecutionContext
-    )(
-      implicit F: Async[F],
+    )(implicit F:               Async[F]
     ): GraphQL[F] =
       new GraphQL[F] {
 
@@ -85,16 +112,20 @@ object SangriaGraphQL {
         }
 
         // Parse `query` and execute.
-        def query(query: String, operationName: Option[String], variables: JsonObject): F[Either[Json, Json]] =
-          QueryParser.parse(query)  match {
-            case Success(ast)                       => exec(schema, userContext, ast, operationName, variables)(blockingExecutionContext)
-            case Failure(e @ SyntaxError(_, _, pe)) => fail(formatSyntaxError(e))
-            case Failure(e)                         => fail(formatThrowable(e))
+        def query(
+          query:         String,
+          operationName: Option[String],
+          variables:     JsonObject
+        ): F[Either[Json, Json]] =
+          QueryParser.parse(query) match {
+            case Success(ast) =>
+              exec(schema, userContext, ast, operationName, variables)(blockingExecutionContext)
+            case Failure(e @ SyntaxError(_, _, _)) => fail(formatSyntaxError(e))
+            case Failure(e)                        => fail(formatThrowable(e))
           }
 
         // Lift a `Json` into the error side of our effect.
-        def fail(j: Json): F[Either[Json, Json]] =
-          F.pure(j.asLeft)
+        def fail(j: Json): F[Either[Json, Json]] = F.pure(j.asLeft)
 
         // Execute a GraphQL query with Sangria, lifting into IO for safety and sanity.
         def exec(
@@ -103,34 +134,36 @@ object SangriaGraphQL {
           query:         Document,
           operationName: Option[String],
           variables:     JsonObject
-        )(implicit ec: ExecutionContext): F[Either[Json, Json]] =
-          userContext.flatMap { ctx =>
-            F.async { (cb: Either[Throwable, Json] => Unit) =>
-              Executor.execute(
-                schema           = schema,
-                deferredResolver = deferredResolver,
-                queryAst         = query,
-                userContext      = ctx,
-                variables        = Json.fromJsonObject(variables),
-                operationName    = operationName,
-                exceptionHandler = ExceptionHandler {
-                  case (_, e) => HandledException(e.getMessage)
-                }
-              ).onComplete {
-                case Success(value) => cb(Right(value))
-                case Failure(error) => cb(Left(error))
-              }
-            }
-          } .attempt.flatMap {
-            case Right(json)               => F.pure(json.asRight)
-            case Left(err: WithViolations) => fail(formatWithViolations(err))
-            case Left(err)                 => fail(formatThrowable(err))
-          }
+        )(implicit ec:   ExecutionContext
+        ): F[Either[Json, Json]] =
+          for {
+            ctx <- userContext
+            attempt <- F.async_ { (cb: Either[Throwable, Json] => Unit) =>
+                         Executor
+                           .execute(
+                             schema           = schema,
+                             deferredResolver = deferredResolver,
+                             queryAst         = query,
+                             userContext      = ctx,
+                             variables        = Json.fromJsonObject(variables),
+                             operationName    = operationName,
+                             exceptionHandler =
+                               ExceptionHandler { case (_, e) => HandledException(e.getMessage) }
+                           )
+                           .onComplete {
+                             case Success(value) => cb(Right(value))
+                             case Failure(error) => cb(Left(error))
+                           }
+                       }.attempt
+            result <- attempt match {
+                        case Right(json)               => F.pure(json.asRight)
+                        case Left(err: WithViolations) => fail(formatWithViolations(err))
+                        case Left(err)                 => fail(formatThrowable(err))
+                      }
+          } yield result
 
       }
-    }
 
   }
 
-
-
+}

--- a/modules/core/src/main/scala/sangria/SangriaGraphQL.scala
+++ b/modules/core/src/main/scala/sangria/SangriaGraphQL.scala
@@ -114,7 +114,7 @@ object SangriaGraphQL {
                 variables        = Json.fromJsonObject(variables),
                 operationName    = operationName,
                 exceptionHandler = ExceptionHandler {
-                  case (_, e) ⇒ HandledException(e.getMessage)
+                  case (_, e) => HandledException(e.getMessage)
                 }
               ).onComplete {
                 case Success(value) => cb(Right(value))

--- a/modules/core/src/main/scala/schema/CityType.scala
+++ b/modules/core/src/main/scala/schema/CityType.scala
@@ -4,44 +4,41 @@
 
 package demo.schema
 
-import cats.effect.Effect
+import cats.effect.Async
+import cats.effect.std.Dispatcher
 import demo.model._
 import demo.repo._
 import sangria.schema._
 
 object CityType {
 
-  def apply[F[_]: Effect]: ObjectType[MasterRepo[F], City] =
+  def apply[F[_]: Async](dispatcher: Dispatcher[F]): ObjectType[MasterRepo[F], City] =
     ObjectType(
-      name     = "City",
-      fieldsFn = () => fields(
-
-        Field(
-          name        = "name",
-          fieldType   = StringType,
-          description = Some("City name."),
-          resolve     = _.value.name),
-
-        Field(
-          name        = "country",
-          fieldType   = CountryType[F],
-          description = Some("Country in which this city resides."),
-          resolve     = e => CountryType.Deferred.ByCode(e.value.countryCode)
-        ),
-
-        Field(
-          name        = "district",
-          fieldType   = StringType,
-          description = Some("District in which this city resides."),
-          resolve     = _.value.district),
-
-        Field(
-          name        = "population",
-          fieldType   = IntType,
-          description = Some("City population."),
-          resolve     = _.value.population),
-
-      )
+      name = "City",
+      fieldsFn = () =>
+        fields(
+          Field(name        = "name",
+                fieldType   = StringType,
+                description = Some("City name."),
+                resolve     = _.value.name
+               ),
+          Field(
+            name        = "country",
+            fieldType   = CountryType[F](dispatcher),
+            description = Some("Country in which this city resides."),
+            resolve     = e => CountryType.Deferred.ByCode(e.value.countryCode)
+          ),
+          Field(name        = "district",
+                fieldType   = StringType,
+                description = Some("District in which this city resides."),
+                resolve     = _.value.district
+               ),
+          Field(name        = "population",
+                fieldType   = IntType,
+                description = Some("City population."),
+                resolve     = _.value.population
+               )
+        )
     )
 
 }

--- a/modules/core/src/main/scala/schema/CountryType.scala
+++ b/modules/core/src/main/scala/schema/CountryType.scala
@@ -5,7 +5,7 @@
 package demo.schema
 
 import cats.effect._
-import cats.effect.implicits._
+import cats.effect.std.Dispatcher
 import demo.model._
 import demo.repo._
 import sangria.execution.deferred.Deferred
@@ -17,109 +17,49 @@ object CountryType {
     final case class ByCode(code: String) extends Deferred[Country]
   }
 
-  def apply[F[_]: Effect]: ObjectType[MasterRepo[F], Country] =
+  def apply[F[_]: Async](dispatcher: Dispatcher[F]): ObjectType[MasterRepo[F], Country] =
     ObjectType(
-      name     = "Country",
-      fieldsFn = () => fields(
-
-        Field(
-          name           = "name",
-          fieldType      = StringType,
-          resolve        = _.value.name
-        ),
-
-        Field(
-          name           = "continent",
-          fieldType      = StringType,
-          resolve        = _.value.continent
-        ),
-
-        Field(
-          name           = "region",
-          fieldType      = StringType,
-          resolve        = _.value.region
-        ),
-
-        Field(
-          name           = "surfacearea",
-          fieldType      = FloatType,
-          resolve        = _.value.surfacearea.toDouble // this is a float
-        ),
-
-        Field(
-          name           = "indepyear",
-          fieldType      = OptionType(IntType), // should be ShortType
-          resolve        = _.value.indepyear.map(_.toInt)
-        ),
-
-        Field(
-          name           = "population",
-          fieldType      = IntType,
-          resolve        = _.value.population
-        ),
-
-        Field(
-          name           = "lifeexpectancy",
-          fieldType      = OptionType(FloatType),
-          resolve        = _.value.lifeexpectancy.map(_.toDouble) //
-        ),
-
-        Field(
-          name           = "gnp",
-          fieldType      = OptionType(BigDecimalType),
-          resolve        = _.value.gnp
-        ),
-
-        Field(
-          name           = "gnpold",
-          fieldType      = OptionType(BigDecimalType),
-          resolve        = _.value.gnpold
-        ),
-
-        Field(
-          name           = "localname",
-          fieldType      = StringType,
-          resolve        = _.value.localname
-        ),
-
-        Field(
-          name           = "governmentform",
-          fieldType      = StringType,
-          resolve        = _.value.governmentform
-        ),
-
-        Field(
-          name           = "headofstate",
-          fieldType      = OptionType(StringType),
-          resolve        = _.value.headofstate
-        ),
-
-        Field(
-          name           = "capitalId",
-          fieldType      = OptionType(IntType),
-          resolve        = _.value.capitalId
-        ),
-
-        Field(
-          name           = "code2",
-          fieldType      = StringType,
-          resolve        = _.value.code2
-        ),
-
-        Field(
-          name           = "cities",
-          fieldType      = ListType(CityType[F]),
-          resolve        = e => e.ctx.city.fetchByCountryCode(e.value.code).toIO.unsafeToFuture()
-        ),
-
-        Field(
-          name           = "languages",
-          fieldType      = ListType(LanguageType[F]),
-          resolve        = e => LanguageType.Deferred.ByCountryCode(e.value.code)
+      name = "Country",
+      fieldsFn = () =>
+        fields(
+          Field(name = "name", fieldType      = StringType, resolve = _.value.name),
+          Field(name = "continent", fieldType = StringType, resolve = _.value.continent),
+          Field(name = "region", fieldType    = StringType, resolve = _.value.region),
+          Field(
+            name      = "surfacearea",
+            fieldType = FloatType,
+            resolve   = _.value.surfacearea.toDouble // this is a float
+          ),
+          Field(name      = "indepyear",
+                fieldType = OptionType(IntType), // should be ShortType
+                resolve   = _.value.indepyear.map(_.toInt)
+               ),
+          Field(name = "population", fieldType = IntType, resolve = _.value.population),
+          Field(
+            name      = "lifeexpectancy",
+            fieldType = OptionType(FloatType),
+            resolve   = _.value.lifeexpectancy.map(_.toDouble) //
+          ),
+          Field(name      = "gnp", fieldType            = OptionType(BigDecimalType), resolve = _.value.gnp),
+          Field(name      = "gnpold", fieldType         = OptionType(BigDecimalType), resolve = _.value.gnpold),
+          Field(name      = "localname", fieldType      = StringType, resolve                 = _.value.localname),
+          Field(name      = "governmentform", fieldType = StringType, resolve                 = _.value.governmentform),
+          Field(name      = "headofstate",
+                fieldType = OptionType(StringType),
+                resolve   = _.value.headofstate
+               ),
+          Field(name      = "capitalId", fieldType = OptionType(IntType), resolve = _.value.capitalId),
+          Field(name      = "code2", fieldType     = StringType, resolve          = _.value.code2),
+          Field(name      = "cities",
+                fieldType = ListType(CityType[F](dispatcher)),
+                resolve =
+                  e => dispatcher.unsafeToFuture(e.ctx.city.fetchByCountryCode(e.value.code))
+               ),
+          Field(name      = "languages",
+                fieldType = ListType(LanguageType[F]),
+                resolve   = e => LanguageType.Deferred.ByCountryCode(e.value.code)
+               )
         )
-
-      )
     )
-
 
 }

--- a/modules/core/src/main/scala/schema/CountryType.scala
+++ b/modules/core/src/main/scala/schema/CountryType.scala
@@ -109,7 +109,7 @@ object CountryType {
         Field(
           name           = "cities",
           fieldType      = ListType(CityType[F]),
-          resolve        = e => e.ctx.city.fetchByCountryCode(e.value.code).toIO.unsafeToFuture
+          resolve        = e => e.ctx.city.fetchByCountryCode(e.value.code).toIO.unsafeToFuture()
         ),
 
         Field(

--- a/modules/core/src/main/scala/schema/LanguageType.scala
+++ b/modules/core/src/main/scala/schema/LanguageType.scala
@@ -17,28 +17,13 @@ object LanguageType {
 
   def apply[F[_]]: ObjectType[MasterRepo[F], Language] =
     ObjectType(
-      name     = "Language",
-      fieldsFn = () => fields(
-
-        Field(
-          name      = "language",
-          fieldType =  StringType,
-          resolve   = _.value.language
-        ),
-
-        Field(
-          name      = "isOfficial",
-          fieldType =  BooleanType,
-          resolve   = _.value.isOfficial
-        ),
-
-        Field(
-          name      = "percentage",
-          fieldType =  FloatType,
-          resolve   = _.value.percentage.toDouble
-        ),
-
-      )
+      name = "Language",
+      fieldsFn = () =>
+        fields(
+          Field(name = "language", fieldType   = StringType, resolve  = _.value.language),
+          Field(name = "isOfficial", fieldType = BooleanType, resolve = _.value.isOfficial),
+          Field(name = "percentage", fieldType = FloatType, resolve   = _.value.percentage.toDouble)
+        )
     )
 
 }

--- a/modules/core/src/main/scala/schema/LanguageType.scala
+++ b/modules/core/src/main/scala/schema/LanguageType.scala
@@ -4,7 +4,6 @@
 
 package demo.schema
 
-import cats.effect.Effect
 import demo.model._
 import demo.repo._
 import sangria.execution.deferred.Deferred
@@ -16,7 +15,7 @@ object LanguageType {
     case class ByCountryCode(code: String) extends Deferred[List[Language]]
   }
 
-  def apply[F[_]: Effect]: ObjectType[MasterRepo[F], Language] =
+  def apply[F[_]]: ObjectType[MasterRepo[F], Language] =
     ObjectType(
       name     = "Language",
       fieldsFn = () => fields(

--- a/modules/core/src/main/scala/schema/MutationType.scala
+++ b/modules/core/src/main/scala/schema/MutationType.scala
@@ -35,7 +35,7 @@ object MutationType {
           fieldType   = OptionType(CountryType[F]),
           description = Some("Update the specified Country, if it exists."),
           arguments   = List(Code, NewName),
-          resolve     = c => c.ctx.country.update(c.arg(Code), c.arg(NewName)).toIO.unsafeToFuture
+          resolve     = c => c.ctx.country.update(c.arg(Code), c.arg(NewName)).toIO.unsafeToFuture()
         ),
 
       )

--- a/modules/core/src/main/scala/schema/MutationType.scala
+++ b/modules/core/src/main/scala/schema/MutationType.scala
@@ -5,39 +5,33 @@
 package demo.schema
 
 import cats.effect._
-import cats.effect.implicits._
+import cats.effect.std.Dispatcher
 import demo.repo._
 import sangria.schema._
 
 object MutationType {
 
-  val NewName: Argument[String] =
-    Argument(
-      name         = "newName",
-      argumentType = StringType,
-      description  = "New name for the specified country.",
-    )
+  val NewName: Argument[String] = Argument(name = "newName",
+                                           argumentType = StringType,
+                                           description  = "New name for the specified country."
+                                          )
 
   val Code: Argument[String] =
-    Argument(
-      name         = "code",
-      argumentType = StringType,
-      description  = "Unique code of a country."
-    )
+    Argument(name = "code", argumentType = StringType, description = "Unique code of a country.")
 
-  def apply[F[_]: Effect]: ObjectType[MasterRepo[F], Unit] =
+  def apply[F[_]: Async](dispatcher: Dispatcher[F]): ObjectType[MasterRepo[F], Unit] =
     ObjectType(
-      name  = "Mutation",
+      name = "Mutation",
       fields = fields(
-
         Field(
           name        = "updateCountry",
-          fieldType   = OptionType(CountryType[F]),
+          fieldType   = OptionType(CountryType[F](dispatcher)),
           description = Some("Update the specified Country, if it exists."),
           arguments   = List(Code, NewName),
-          resolve     = c => c.ctx.country.update(c.arg(Code), c.arg(NewName)).toIO.unsafeToFuture()
-        ),
-
+          resolve = c =>
+            dispatcher
+              .unsafeToFuture(c.ctx.country.update(c.arg(Code), c.arg(NewName)))
+        )
       )
     )
 

--- a/modules/core/src/main/scala/schema/QueryType.scala
+++ b/modules/core/src/main/scala/schema/QueryType.scala
@@ -36,7 +36,7 @@ object QueryType {
           fieldType   = ListType(CityType[F]),
           description = Some("Returns cities with the given name pattern, if any."),
           arguments   = List(NamePattern),
-          resolve     = c => c.ctx.city.fetchAll(c.argOpt(NamePattern)).toIO.unsafeToFuture
+          resolve     = c => c.ctx.city.fetchAll(c.argOpt(NamePattern)).toIO.unsafeToFuture()
         ),
 
         Field(
@@ -44,14 +44,14 @@ object QueryType {
           fieldType   = OptionType(CountryType[F]),
           description = Some("Returns the country with the given code, if any."),
           arguments   = List(Code),
-          resolve     = c => c.ctx.country.fetchByCode(c.arg(Code)).toIO.unsafeToFuture
+          resolve     = c => c.ctx.country.fetchByCode(c.arg(Code)).toIO.unsafeToFuture()
         ),
 
         Field(
           name        = "countries",
           fieldType   = ListType(CountryType[F]),
           description = Some("Returns all countries."),
-          resolve     = c => c.ctx.country.fetchAll.toIO.unsafeToFuture
+          resolve     = c => c.ctx.country.fetchAll.toIO.unsafeToFuture()
         ),
 
       )

--- a/modules/core/src/main/scala/schema/QueryType.scala
+++ b/modules/core/src/main/scala/schema/QueryType.scala
@@ -5,59 +5,50 @@
 package demo.schema
 
 import cats.effect._
-import cats.effect.implicits._
+import cats.effect.std.Dispatcher
 import demo.repo._
 import sangria.schema._
 
 object QueryType {
 
-  val NamePattern: Argument[String] =
-    Argument(
-      name         = "namePattern",
-      argumentType = OptionInputType(StringType),
-      description  = "SQL-style pattern for city name, like \"San %\".",
-      defaultValue = "%"
-    )
+  val NamePattern: Argument[String] = Argument(name = "namePattern",
+                                               argumentType = OptionInputType(StringType),
+                                               description =
+                                                 "SQL-style pattern for city name, like \"San %\".",
+                                               defaultValue = "%"
+                                              )
 
   val Code: Argument[String] =
-    Argument(
-      name         = "code",
-      argumentType = StringType,
-      description  = "Unique code of a country."
-    )
+    Argument(name = "code", argumentType = StringType, description = "Unique code of a country.")
 
-  def apply[F[_]: Effect]: ObjectType[MasterRepo[F], Unit] =
+  def apply[F[_]: Async](dispatcher: Dispatcher[F]): ObjectType[MasterRepo[F], Unit] =
     ObjectType(
-      name  = "Query",
+      name = "Query",
       fields = fields(
-
         Field(
           name        = "cities",
-          fieldType   = ListType(CityType[F]),
+          fieldType   = ListType(CityType[F](dispatcher)),
           description = Some("Returns cities with the given name pattern, if any."),
           arguments   = List(NamePattern),
-          resolve     = c => c.ctx.city.fetchAll(c.argOpt(NamePattern)).toIO.unsafeToFuture()
+          resolve     = c => dispatcher.unsafeToFuture(c.ctx.city.fetchAll(c.argOpt(NamePattern)))
         ),
-
         Field(
           name        = "country",
-          fieldType   = OptionType(CountryType[F]),
+          fieldType   = OptionType(CountryType[F](dispatcher)),
           description = Some("Returns the country with the given code, if any."),
           arguments   = List(Code),
-          resolve     = c => c.ctx.country.fetchByCode(c.arg(Code)).toIO.unsafeToFuture()
+          resolve     = c => dispatcher.unsafeToFuture(c.ctx.country.fetchByCode(c.arg(Code)))
         ),
-
         Field(
           name        = "countries",
-          fieldType   = ListType(CountryType[F]),
+          fieldType   = ListType(CountryType[F](dispatcher)),
           description = Some("Returns all countries."),
-          resolve     = c => c.ctx.country.fetchAll.toIO.unsafeToFuture()
-        ),
-
+          resolve     = c => dispatcher.unsafeToFuture(c.ctx.country.fetchAll)
+        )
       )
     )
 
-  def schema[F[_]: Effect]: Schema[MasterRepo[F], Unit] =
-    Schema(QueryType[F])
+  def schema[F[_]: Async](dispatcher: Dispatcher[F]): Schema[MasterRepo[F], Unit] =
+    Schema(QueryType[F](dispatcher))
 
 }

--- a/modules/core/src/main/scala/schema/WorldDeferredResolver.scala
+++ b/modules/core/src/main/scala/schema/WorldDeferredResolver.scala
@@ -60,8 +60,8 @@ object WorldDeferredResolver {
           } yield ()
 
         // WARNING WARNING WARNING
-        completeCountries(select[CountryType.Deferred.ByCode]).toIO.unsafeToFuture
-        completeLanguages(select[LanguageType.Deferred.ByCountryCode]).toIO.unsafeToFuture
+        completeCountries(select[CountryType.Deferred.ByCode]).toIO.unsafeToFuture()
+        completeLanguages(select[LanguageType.Deferred.ByCountryCode]).toIO.unsafeToFuture()
         // Let's hope there are no more cases, who the hell knows. Any orphaned Promises will just
         // wait forever and eventually we'll time out. I assume.
 

--- a/modules/core/src/main/scala/schema/WorldDeferredResolver.scala
+++ b/modules/core/src/main/scala/schema/WorldDeferredResolver.scala
@@ -5,26 +5,27 @@
 package demo.schema
 
 import cats.effect._
-import cats.effect.implicits._
+import cats.effect.Async
 import cats.implicits._
 import demo.repo._
-import sangria.execution.deferred.{ Deferred, DeferredResolver }
+import sangria.execution.deferred.Deferred
+import sangria.execution.deferred.DeferredResolver
 import scala.concurrent.ExecutionContext
 import scala.concurrent._
 import scala.reflect.ClassTag
 import scala.util.Success
+import cats.effect.unsafe.implicits.global
 
 object WorldDeferredResolver {
 
-  def apply[F[_]: Effect]: DeferredResolver[MasterRepo[F]] =
+  def apply[F[_]: Async]: DeferredResolver[MasterRepo[F]] =
     new DeferredResolver[MasterRepo[F]] {
 
       def resolve(
-        deferred:   Vector[Deferred[Any]],
-        ctx:        MasterRepo[F],
-        queryState: Any
-      )(
-        implicit ec: ExecutionContext
+        deferred:    Vector[Deferred[Any]],
+        ctx:         MasterRepo[F],
+        queryState:  Any
+      )(implicit ec: ExecutionContext
       ): Vector[Future[Any]] = {
 
         // So what we're going to do is create a map of Deferred to Promise and the complete them
@@ -38,12 +39,14 @@ object WorldDeferredResolver {
 
         // Select the distinct Deferreds of the given class. This is feckin desperate but we're
         // given Any so not a whole lot of choices.
-        def select[A <: Deferred[Any] : ClassTag]: List[A] =
-          promises.keys.collect { case a: A => a } .toList
+        def select[A <: Deferred[Any]: ClassTag]: List[A] =
+          promises.keys.collect { case a: A => a }.toList
 
         // Complete the promise associated with a Deferred
-        def complete[A](d: Deferred[A], a: A): F[Unit] =
-          Effect[F].delay(promises(d).complete(Success(a))).void
+        def complete[A](
+          d: Deferred[A],
+          a: A
+        ): F[Unit] = Sync[F].delay(promises(d).complete(Success(a))).void
 
         // Complete a bunch of countries by doing a batch database query
         def completeCountries(codes: List[CountryType.Deferred.ByCode]): F[Unit] =
@@ -56,12 +59,15 @@ object WorldDeferredResolver {
         def completeLanguages(codes: List[LanguageType.Deferred.ByCountryCode]): F[Unit] =
           for {
             m <- ctx.language.fetchByCountryCodes(codes.map(_.code))
-            _ <- m.toList.traverse { case (c, ls) => complete(LanguageType.Deferred.ByCountryCode(c), ls) }
+            _ <- m.toList.traverse { case (c, ls) =>
+                   complete(LanguageType.Deferred.ByCountryCode(c), ls)
+                 }
           } yield ()
 
         // WARNING WARNING WARNING
-        completeCountries(select[CountryType.Deferred.ByCode]).toIO.unsafeToFuture()
-        completeLanguages(select[LanguageType.Deferred.ByCountryCode]).toIO.unsafeToFuture()
+        (IO(completeCountries(select[CountryType.Deferred.ByCode])) >>
+        IO(completeLanguages(select[LanguageType.Deferred.ByCountryCode]))).unsafeToFuture()
+
         // Let's hope there are no more cases, who the hell knows. Any orphaned Promises will just
         // wait forever and eventually we'll time out. I assume.
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
-//scalaVersion := "2.13.8"r
-//addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.2")
+scalaVersion := "2.12.15"
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.2")
 addSbtPlugin("de.heikoseeberger"  % "sbt-header"      % "5.6.0")
-//addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.0")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
-scalaVersion := "2.12.11"
-
-addSbtPlugin("com.timushev.sbt"   % "sbt-updates"     % "0.5.0")
+//scalaVersion := "2.13.8"r
+//addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.2")
 addSbtPlugin("de.heikoseeberger"  % "sbt-header"      % "5.6.0")
-addSbtPlugin("io.spray"           % "sbt-revolver"    % "0.9.1")
-
+//addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.0")


### PR DESCRIPTION
This PR updates dependencies, including Cats Effect 3 which has many changes from Cats Effect 2. 
This was my guide: https://typelevel.org/cats-effect/docs/migration-guide.

The PR also include a scalafmt config copied from the typelevel/cats-effect repo, so there are formatting changes. 

The logger is also being created wherever it is used, which is the safer and clearer way
(https://typelevel.org/log4cats/#examples).

Overall, it's runnable, and it works like the original.

